### PR TITLE
Remove dangerous call to redis flushdb

### DIFF
--- a/src/TreeHouse/Cache/Adapter/DoctrineAdapter.php
+++ b/src/TreeHouse/Cache/Adapter/DoctrineAdapter.php
@@ -60,7 +60,7 @@ class DoctrineAdapter extends CacheProvider
      */
     protected function doFlush()
     {
-        return $this->cache->clear();
+        throw new \RuntimeException('Not supported');
     }
 
     /**


### PR DESCRIPTION
The `doctine:cache:clear-*` commands have a `--flush` option. When using that option in combination with redis cache, it will result in a destructive [flushdb call](https://github.com/treehouselabs/cache/blob/master/src/TreeHouse/Cache/Driver/RedisDriver.php#L63), wiping out all data in redis, not only doctrine keys. We think it's better to not support such a destructive action.

I'm open for discussion on this matter as I don't think this is the best solution. 

For now we have also chosen to store doctrine keys in a separate redis db, that way other keys are never affected by a flushdb. But I believe that that solution depends too much on configuration, which can easily be forgotten.